### PR TITLE
Add validation for salary and interview dates in prospect entries

### DIFF
--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -21,3 +21,214 @@ describe("prospect creation validation", () => {
     expect(result.errors).toContain("Role title is required");
   });
 });
+
+describe("salary validation", () => {
+  test("accepts a plain numeric salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: "120000",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts salary with commas", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: "120,000",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts salary with dollar sign", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: "$120,000",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts salary with decimals", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: "120000.50",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts empty salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: "",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts null salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts undefined salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects non-numeric salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: "abc",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a numeric value");
+  });
+
+  test("rejects salary with letters mixed in", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: "120k",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a numeric value");
+  });
+
+  test("rejects non-string salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      salary: 120000,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary must be a numeric value");
+  });
+});
+
+describe("interview date validation", () => {
+  test("accepts valid interview dates", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: ["2026-03-15T10:00", "2026-03-20T14:30"],
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts an empty array of interview dates", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: [],
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts null interview dates", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("accepts undefined interview dates", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects non-array interview dates", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: "2026-03-15T10:00",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Interview dates must be an array");
+  });
+
+  test("rejects invalid date strings in the array", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: ["not-a-date"],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Each interview date must be a valid date-time string");
+  });
+
+  test("rejects non-string values in the array", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: [12345],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Each interview date must be a valid date-time string");
+  });
+
+  test("rejects array with mix of valid and invalid dates", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: ["2026-03-15T10:00", "garbage"],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Each interview date must be a valid date-time string");
+  });
+
+  test("accepts a single valid interview date", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "PM",
+      interviewDates: ["2026-04-01T09:00"],
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,26 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.salary !== undefined && data.salary !== null && data.salary !== "") {
+    const salaryStr = typeof data.salary === "string" ? data.salary.replace(/[,$\s]/g, "") : "";
+    if (!salaryStr || !/^\d+(\.\d+)?$/.test(salaryStr)) {
+      errors.push("Salary must be a numeric value");
+    }
+  }
+
+  if (data.interviewDates !== undefined && data.interviewDates !== null) {
+    if (!Array.isArray(data.interviewDates)) {
+      errors.push("Interview dates must be an array");
+    } else {
+      for (const date of data.interviewDates) {
+        if (typeof date !== "string" || isNaN(new Date(date).getTime())) {
+          errors.push("Each interview date must be a valid date-time string");
+          break;
+        }
+      }
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 


### PR DESCRIPTION
Adds new validation logic and tests for salary and interview dates in prospect entries within prospect-helpers.ts and prospect-validation.test.ts.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 93a081bd-25c3-4eee-989d-3b840c20bc7e
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 3ed6078e-24b3-4953-8608-1b244bd9c623
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/e9a14291-4832-4b97-b228-0b2dad112d61/93a081bd-25c3-4eee-989d-3b840c20bc7e/IeGagxx
Replit-Helium-Checkpoint-Created: true